### PR TITLE
Restore follow button style

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -112,8 +112,8 @@ button[data-testid="tweetButtonInline"],
 button[data-testid="confirmationSheetConfirm"],
 [data-testid="UserCell"] button[data-testid$="-follow"],
 [data-testid="placementTracking"] button[data-testid$="-follow"] {
-    background-color: ${oldButtonStyle ? `transparent!important` : "inherit"};
-    border: ${oldButtonStyle ? `2px solid ${twitterBlue}!important` : "inherit"};
+    background-color: ${oldButtonStyle ? 'transparent!important' : 'rgb(215,219,220)'};
+    border: ${oldButtonStyle ? '2px solid ' + twitterBlue + '!important' : 'inherit'};
 }
 
 a[data-testid="SideNav_NewTweet_Button"] > div,
@@ -122,7 +122,7 @@ button[data-testid="tweetButtonInline"] > div,
 button[data-testid="confirmationSheetConfirm"] > div,
 [data-testid="UserCell"] button[data-testid$="-follow"] > div,
 [data-testid="placementTracking"] button[data-testid$="-follow"] > div {
-    color: ${oldButtonStyle ? `${twitterBlue}!important` : "inherit"};
+    color: ${oldButtonStyle ? twitterBlue + '!important' : 'inherit'};
 }
 
 [data-color-scheme="dark"] h1 a[href=\'/home\'] svg {

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,7 @@ const twitterBlueIconPath = 'M15.704 8.99c.457-.05.891-.17 1.296-.35-.302.45-.68
 
 const twitterBlue = 'rgb(29,155,240)'
 const twitterGray = 'rgb(231,233,234)'
+const oldButtonStyle = true
 
 const linkMap: Record<string, string> = {
     'mask-icon': 'https://abs.twimg.com/responsive-web/client-web/icon-svg.168b89da.svg',
@@ -109,8 +110,19 @@ a[data-testid="SideNav_NewTweet_Button"],
 button[data-testid="tweetButton"],
 button[data-testid="tweetButtonInline"],
 button[data-testid="confirmationSheetConfirm"],
-[data-testid="UserCell"] button[data-testid$="-follow"] {
-    background-color: ${twitterBlue}!important;
+[data-testid="UserCell"] button[data-testid$="-follow"],
+[data-testid="placementTracking"] button[data-testid$="-follow"] {
+    background-color: ${oldButtonStyle ? `transparent!important` : "inherit"};
+    border: ${oldButtonStyle ? `2px solid ${twitterBlue}!important` : "inherit"};
+}
+
+a[data-testid="SideNav_NewTweet_Button"] > div,
+button[data-testid="tweetButton"] > div,
+button[data-testid="tweetButtonInline"] > div,
+button[data-testid="confirmationSheetConfirm"] > div,
+[data-testid="UserCell"] button[data-testid$="-follow"] > div,
+[data-testid="placementTracking"] button[data-testid$="-follow"] > div {
+    color: ${oldButtonStyle ? `${twitterBlue}!important` : "inherit"};
 }
 
 [data-color-scheme="dark"] h1 a[href=\'/home\'] svg {


### PR DESCRIPTION
I gave back the old look for the Follow and Tweet buttons for those who want ¯\_(ツ)_/¯ (with the ability to easily toggle them with a true and false const named "oldButtonStyle")